### PR TITLE
Changed back cc1v1's name in the tierpoll

### DIFF
--- a/infinite/commands/poll.js
+++ b/infinite/commands/poll.js
@@ -115,7 +115,7 @@ module.exports = {
     tierspoll: 'tierpoll',
     tierpoll: function(target, room, user) {
         if (!this.can('broadcast', null, room)) return this.sendReply('/tierpoll - Access denied.');
-        this.parse('/poll Tournament Tier, Ubers, OU, UU, RU, NU, PU, LC, Monotype, Anything Goes, Random Battle, Random Monotype, Doubles OU, Seasonal, Battle Factory, Battle Cup 1v1, Challenge Cup, Gen 1 Random Battle, 1v1, Super Staff Bros.');
+        this.parse('/poll Tournament Tier, Ubers, OU, UU, RU, NU, PU, LC, Monotype, Anything Goes, Random Battle, Random Monotype, Doubles OU, Seasonal, Battle Factory, Challenge Cup 1v1, Challenge Cup, Gen 1 Random Battle, 1v1, Super Staff Bros.');
     },
 
     hv: 'helpvotes',


### PR DESCRIPTION
Since Main made cc1v1 be named cc1v1 again instead of bc1v1, might as well change it in the poll too, so that the users don't get confused.